### PR TITLE
Adding Terraform, Beanstalk & Deploybot

### DIFF
--- a/ci-servers.md
+++ b/ci-servers.md
@@ -37,6 +37,7 @@ Here are a few of the CI servers you might encounter:
 * [Drone](https://github.com/drone/drone) is an open-source (and [hosted](https://drone.io/) ) Continuous Integration platform built on Docker
 * [Bamboo](https://www.atlassian.com/software/bamboo) Bamboo is an Atlassian CI/CD tool that integrates seamlessly with other Atlassian products such as JIRA, Confluence and Stash.
 * [Codeship](https://codeship.com) Codeship is a hosted CI/CD service. Codeship will run your project's unit tests, and can also deploy new code to your servers via Capistrano, Amazon EBS, Heroku, custom scripts, and many others.
+* [DeployBot](http://deploybot.com). DeployBot is a hosted service that provides many repository, environment and service integrations. It also features automated code compilation.
 
 
 ## Continuous Deployment

--- a/codebase.md
+++ b/codebase.md
@@ -33,6 +33,7 @@ The following table lists hosting services managed by a 3rd party.  The pricing 
 * [BitBucket](https://bitbucket.org/).  [Atlassian](https://www.atlassian.com/)'s Git hosting solution.
 * [GitLab.com](https://www.gitlab.com/). A hosting service based on the popular open source project GitLab HQ.
 * [Gitorious](https://gitorious.org/). Similar to GitLab, a hosted version of an open source tool that you can install and maintain yourself.
+* [Beanstalk](http://beanstalkapp.com). Beanstalk hosts Git and SVN repositories. It also provides webhooks and many built-in integrations for continuous deployment and automation.
 
 These are services that you can install and manage in your own environment:
 

--- a/manage-environment.md
+++ b/manage-environment.md
@@ -20,6 +20,7 @@ The following table lists some of the configuration and environment automation t
 * [Salt](http://www.saltstack.com/). "Fast, scalable and flexible software for data center automation, from infrastructure and any cloud, to the entire application stack"
 * [Docker](https://www.docker.io/learn/dockerfile/level1/). "If you're building a Docker image, you can specify a lot of the dependencies by specifying a [dockerfile](https://www.docker.io/learn/dockerfile/level1/) for the container."
 * [Juju](https://juju.ubuntu.com/). "Juju lets you define applications as charms that know how to setup your app and relate it to other charms. It has a charmstore which contains many community reviewed charms for existing services. Using juju these charms can be deployed to many existing cloud providers or locally using LXC"
+* [Terraform](https://terraform.io). "Terraform allows you to effortlessly combine high-level system providers with your own or with each other – from physical and virtual servers to email and DNS providers."
 
 ## For More Information
 

--- a/monitoring.md
+++ b/monitoring.md
@@ -26,4 +26,5 @@ Here are some monitoring tools you might encounter:
 * [Grafana](http://grafana.org/) is an open source, feature-rich metrics dashboard and graph editor for Graphite, InfluxDB & OpenTSDB.
 * [Apache Logging Services](http://logging.apache.org/) includes the popular logging libraries log4j, log4net, etc, as well as the Chainsaw viewer, that developers can use to quickly log in-application events to files, databases table, or external services.
 * [Loggly](https://www.loggly.com/) is a cloud logging service (from developers that worked on Splunk) with a generous free tier.
-* [Splunk](http://www.splunk.com/), [Zenoss](http://www.zenoss.com/) are on-site solutions designed to manage hundreds to thousands of servers. Zenoss is open source.
+* [Splunk](http://www.splunk.com/). Splunk is a data collection and analytics tool. Splunk offers three versions: Enterprise (on-prem or self-hosted), Cloud (SaaS) and Light (either self-hosted or as a service).
+* [Zenoss](http://www.zenoss.org/). Zenoss Core is an open source tool that provides full stack monitoring. Zenoss, Inc. also offers the commercial product [Zenoss Service Dynamics](http://www.zenoss.com) for both on-prem and as-a-service.

--- a/monitoring.md
+++ b/monitoring.md
@@ -28,3 +28,4 @@ Here are some monitoring tools you might encounter:
 * [Loggly](https://www.loggly.com/) is a cloud logging service (from developers that worked on Splunk) with a generous free tier.
 * [Splunk](http://www.splunk.com/). Splunk is a data collection and analytics tool. Splunk offers three versions: Enterprise (on-prem or self-hosted), Cloud (SaaS) and Light (either self-hosted or as a service).
 * [Zenoss](http://www.zenoss.org/). Zenoss Core is an open source tool that provides full stack monitoring. Zenoss, Inc. also offers the commercial product [Zenoss Service Dynamics](http://www.zenoss.com) for both on-prem and as-a-service.
+* [ELK Stack](https://www.elastic.co). Elastic's open source products Elasticsearch, Logstash and Kibana are commonly used together and known as the "ELK Stack." Logstash provides data collection and transport; Elasticsearch provides storage, data search and analytics; and Kibana is a data vizualization platform.


### PR DESCRIPTION
Terraform is Hashicorp's tool to manage hosted and private servers with a single tool.
Beanstalk and Deploybot are Wildbit's services for hosted code repos and continuous delivery/integration.